### PR TITLE
REST Docs + Swagger 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'java'   // Java 플러그인을 적용하여 Java 애플리케이션 빌드 및 테스트 기능을 제공
     id 'org.springframework.boot' version '3.3.2' // Spring Boot 플러그인을 적용하여 Spring Boot 애플리케이션을 설정하고 실행할 수 있도록 도와준다.
     id 'io.spring.dependency-management' version '1.1.6' // 종속성 관리를 위해 사용되며, 종속성 버전을 중앙에서 관리할 수 있도록 해준다.
+    id 'com.epages.restdocs-api-spec' version '0.18.2' // REST Docs로 만든 텍스트를 기반으로 OpenAPI 스펙을 자동 생성하게 해준다.
+    id "org.asciidoctor.jvm.convert" version "3.3.2" // REST Docs가 생성한 AsciiDoc파일을 HTML로 변환해준다.
 }
 
 allprojects {
@@ -33,9 +35,51 @@ subprojects {
 
         testImplementation "org.mockito:mockito-core:5.2.0" // Mocking framework
         testImplementation "org.assertj:assertj-core:3.23.1" // Assertions library
+        testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc' // REST Docs 문서화
+        testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.18.2' // REST Docs로 작성된 테스트를 OpenAPI(Swagger) 규격의 API 명세로 변환
+    }
+
+    // Gradle에서 전역적으로 사용될 수 있는 추가 속성, 테스트 이후 생성되는 snippets가 저장될 경로를 지정
+    ext {
+        snippetsDir = file('build/generated-snippets')
+    }
+
+    // REST Docs로 문서를 만드는 태스크
+    asciidoctor { 
+        dependsOn test // asciidoctor 작업이 실행되기 전에 test 작업이 먼저 실행되도록 설정
+        attributes 'snippets': snippetsDir // 기존에 설정한 디렉토리를 참조하도록 설정
+        inputs.dir snippetsDir // 내부의 파일이 변경되었을 때 문서를 다시 생성
+    }
+
+    asciidoctor.doFirst {
+        delete file('src/main/resources/static/docs') // 기존 문서 삭제로 문서 중복 방지
+    }
+
+    // Spring Boot 애플리케이션에서 실행가능한 JAR 파일로 패키징하는 태스크
+    bootJar {
+        dependsOn asciidoctor
+        copy {
+            from "${asciidoctor.outputDir}"
+            into 'src/main/resources/static/docs'
+        }
+    }
+
+    // OpenAPI 생성
+    openapi3 {
+        servers = [
+                { url = 'http://localhost:8081/v1' }, // 8081 포트에서 사용
+                // { url = 'http://production-api-server-url.com/v1' } // 배포 이후 실제 도메인 주소
+        ]
+        title = 'Our Home Recipe API' // Swagger UI에 표시되는 타이틀
+        description = 'Our Home Recipe' // Swagger UI에 표시되는 설명, MD 형식으로 여러 기능 설명 추가
+        version = '1.0.0'
+        format = 'json'
+        outputFileNamePrefix = 'open-api-3-labeling-service'
+        outputDirectory = 'src/main/resources/static/docs'
     }
 
     test {
+        outputs.dir snippetsDir // 테스트 실행 시 문서화된 스티펫을 해당 디렉토리에 저장
         useJUnitPlatform()
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> [FEATURE] Rest docs + swagger 초기 환경 세팅 #5
> close #5 

## #️⃣ 작업 내용

> REST Docs + Swagger 의존성 추가 (build.gradle)
> 현재 테스트 코드와 문서 구조가 구체화 되지 않아 일단 의존성을 추가하는 과정을 진행했습니다.
> 추후 테스트 코드를 작성할 때까지 이후의 내용을 블로그에 정리하여 공유드리겠습니다. (사용방법, 문법 등)

## #️⃣ 테스트 결과

> 

## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 필요한 경우, 문서를 작성하거나 수정했나요?
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> 예시: 이 부분의 코드가 잘 작동하는지 테스트 해주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요.
